### PR TITLE
Remove HTML Proofer alt ignore flag [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,12 @@ workflows:
           orb-path: orb.yml
           requires:
             - orb-tools/lint
-          context: orbs
+          context: circleci-ctx
       # trigger an integration workflow to test the
       # dev:${CIRCLE_SHA1:0:7} version of your orb
       - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev
-          context: orbs
+          context: circleci-ctx
           requires:
             - orb-tools/publish-dev
   integration-test_deploy:
@@ -68,8 +68,7 @@ workflows:
           filters:
             branches:
               only: trunk
-          context:
-            - orbs
+          context: circleci-ctx
 
 jobs:
   integration-test-install:

--- a/orb.yml
+++ b/orb.yml
@@ -82,7 +82,7 @@ commands:
     steps:
       - run:
           name: "Test generated website with HTML Proofer."
-          command: "htmlproofer << parameters.path >> --allow-hash-href --check-html --empty-alt-ignore --disable-external"
+          command: "htmlproofer << parameters.path >> --allow-hash-href --check-html --disable-external"
   build:
     description: Build a static site with Strawberry located at 'source'. The default is '.'.
     parameters:


### PR DESCRIPTION
This flag is being removed for two reasons.

1. The flag name has changed. Images with newer versions of HTML-Proofer are now failing because of this.
2. The default value of this flag has switched to true, meaning we don't even need it anymore.